### PR TITLE
Add Canva embed component

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 VITE_SUPABASE_URL=https://your-supabase-project-url.supabase.co
 VITE_SUPABASE_ANON_KEY=your-supabase-anon-key
+VITE_CANVA_DESIGN_ID=your-design-id

--- a/src/components/CanvaEmbed.jsx
+++ b/src/components/CanvaEmbed.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+const CanvaEmbed = ({ designId, height = 500 }) => {
+  const id = designId || import.meta.env.VITE_CANVA_DESIGN_ID;
+  if (!id) return null;
+  const src = `https://www.canva.com/design/${id}/view?embed`;
+  return (
+    <div className="canva-embed" style={{ width: '100%', height }}>
+      <iframe
+        loading="lazy"
+        allowFullScreen
+        src={src}
+        style={{ border: 'none', width: '100%', height: '100%' }}
+      />
+    </div>
+  );
+};
+
+export default CanvaEmbed;

--- a/src/index.css
+++ b/src/index.css
@@ -301,6 +301,16 @@ button {
   color: var(--color-gray-300);
 }
 
+.canva-section {
+  margin: 3rem 0;
+  display: flex;
+  justify-content: center;
+}
+
+.canva-embed iframe {
+  border-radius: var(--border-radius);
+}
+
 .welcome-section {
   background-color: var(--color-gray-800);
   padding: 2rem;

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useAuth } from '../context/AuthContext';
 import Header from '../components/layout/Header';
 import Footer from '../components/layout/Footer';
+import CanvaEmbed from '../components/CanvaEmbed';
 
 const HomePage = () => {
   const { user } = useAuth();
@@ -44,6 +45,10 @@ const HomePage = () => {
               <p>Gün boyu enerjik hissedin ve motivasyonunuzu artırın.</p>
             </div>
           </div>
+        </section>
+
+        <section className="canva-section">
+          <CanvaEmbed />
         </section>
 
         {user && (


### PR DESCRIPTION
## Summary
- add `CanvaEmbed` component that renders a Canva design via iframe
- show `CanvaEmbed` on the home page
- style embed section in CSS
- add placeholder env variable for the design id

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685c3140c9d883288ef2df2210614e13